### PR TITLE
#167216440 Filter trips by origin

### DIFF
--- a/controller/tripController.js
+++ b/controller/tripController.js
@@ -106,6 +106,27 @@ class Trip{
             })
         }
     }
+    static async filterTripByOrigin(request, response){
+        try {
+            const data = await trips.select(['*'], [`origin='${request.params.origin}'`]);
+            if(!data[0]){
+                return response.status(404).json({
+                    status: 404,
+                    error: `No available trip for ${request.params.origin} origin`
+                })
+            }
+            return response.status(200).json({
+                status: 200,
+                data,
+                message: `Trips available for ${request.params.origin} origin`
+            })             
+        } catch (error) {
+            return response.status(503).json({
+                status: 503,
+                error: 'Something went wrong, service not available'
+            })
+        }
+    }
 
 }
 

--- a/routes/trips.js
+++ b/routes/trips.js
@@ -10,5 +10,6 @@ router.post('/trip', Authentication.checkToken, tokenAccess.adminAccess, validat
 router.get('/trips', Authentication.checkToken, Controller.viewTrip);
 router.patch('/trips/:tripId', Authentication.checkToken, tokenAccess.adminAccess, validation.tripCancellation, Controller.cancelTrip);
 router.get('/trips/destination/:destination', Authentication.checkToken, validation.filterTripByDestination, Controller.filterTripByDestination);
+router.get('/trips/origin/:origin', Authentication.checkToken, validation.filterTripByOrigin, Controller.filterTripByOrigin);
 
 export default router;

--- a/test/trip.test.js
+++ b/test/trip.test.js
@@ -437,4 +437,41 @@ describe('Test Create Trip', ()=>{
             done()
         })
     })
+    it('should filter trip by origin', (done)=>{
+        chai
+        .request(app)
+        .get(`/api/v1/trips/origin/Lagos`)
+        .set('Authorization', userToken)
+        .end((error, response)=>{
+            expect(response).to.have.status(200);
+            expect(response.body).to.have.property('data');
+            expect(response.body).to.have.property('status').eql(200);
+            done();
+        })
+    })
+    it('should not filter trip by origin if body parameter is passed', (done)=>{
+        chai
+        .request(app)
+        .get(`/api/v1/trips/origin/Lagos`)
+        .send({origin:"Lagos"})
+        .set('Authorization', userToken)
+        .end((error, response)=>{
+            expect(response).to.have.status(400);
+            expect(response.body).to.have.property('error');
+            expect(response.body).to.have.property('status').eql(400);
+            done()
+        })
+    })
+    it('should not filter trip if origin is not vaild', (done)=>{
+        chai
+        .request(app)
+        .get(`/api/v1/trips/origin/$Lagos`)
+        .set('Authorization', userToken)
+        .end((error, response)=>{
+            expect(response).to.have.status(422);
+            expect(response.body).to.have.property('error');
+            expect(response.body).to.have.property('status').eql(422);
+            done()
+        })
+    })
 })

--- a/validation/Trip.js
+++ b/validation/Trip.js
@@ -127,6 +127,21 @@ class TripValidation {
         }
         next();
     }
+    static filterTripByOrigin(request, response, next){
+        if(Object.keys(request.body).length>0){
+            return response.status(400).json({
+                status: 400,
+                error: 'Only origin parameter is required'
+            })
+        }
+        if(!isString.test(request.params.origin)){
+            return response.status(422).json({
+                status: 422,
+                error: 'Origin should contain at least 2 character without invalid symbols'
+            })
+        }
+        next();
+    }
 }
 
 export default TripValidation;


### PR DESCRIPTION
#### What does this PR do?
Have users filter trips by origin
#### Description of Task to be completed?
Have filter trip by origin endpoint working
- `GET localhost:5000/api/v1/trips/origin/:origin`

#### How should this be manually tested?
Clone the repo cd into it and RUN _npm run test_ 
- Using postman test the above endpoint with 
_key_ : Content-Type: _value_ : application/json
- To get authentication, Login or Signup and get TOKEN
_key_: Authorization _value_: Bearer `TOKEN`
#### Any background context you want to provide?
- None
#### What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/167216440
#### Screenshots (if appropriate)
![Screen Shot 2019-07-14 at 1 29 16 PM](https://user-images.githubusercontent.com/46590803/61183815-a9976d00-a63d-11e9-8d25-97e21ffabc3c.png)

#### Questions: